### PR TITLE
Add manageiq-api PR #149

### DIFF
--- a/pending-prs-unstable.json
+++ b/pending-prs-unstable.json
@@ -2,7 +2,8 @@
     "manageiq": [],
     "manageiq-api": [
         76,
-        177
+        177,
+        149
     ],
     "manageiq-providers-kubernetes": [
         192


### PR DESCRIPTION
"Allow assigning/un-assigning of alert definitions to alert profiles"

Doing this as a PR instead of committing manually mostly to test travis integration.