### PR TITLE
Revert "Add manageiq-api PR #149" (not mergeable with other PR)

### DIFF
--- a/pending-prs-unstable.json
+++ b/pending-prs-unstable.json
@@ -2,8 +2,7 @@
     "manageiq": [],
     "manageiq-api": [
         76,
-        177,
-        149
+        177
     ],
     "manageiq-providers-kubernetes": [
         192


### PR DESCRIPTION
This reverts commit 81bfc06dd9e6e84668733f6797ac8dcea2698a78.

It's not mergeable with PR 177, probably needs to be rebased, might only be possible after 149 is merged upstream