### PR TITLE
Support building stable ManageIQ images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,37 @@
 #!/usr/bin/env bash
+# This script clones ManageIQ repos, patch them with pending PRS, pushes to a fork,
+# and triggers a container image build on DockerCloud
 
 # "Bash strict mode" settings - http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -e          # exit on error (like a normal programming langauge)
 set -u          # fail when undefined variables are used
 set -o pipefail # prevent errors in a pipeline from being masked
 
-BRANCH=image-unstable
-PENDING_PRS=${PWD}/pending-prs-unstable.json
+BUILD_TYPE=${1:-unstable}
+BUILD_TIME=$(date +%Y%m%d-%H%M)
+BRANCH=image-${BUILD_TYPE}
+PENDING_PRS=${PWD}/pending-prs-${BUILD_TYPE}.json
 BUILD_ID=${BUILD_ID:-}
-BASEDIR=${PWD}/manageiq-unstable
+BASEDIR=${PWD}/manageiq-${BUILD_TYPE}
 CORE_REPO=manageiq
 GITHUB_ORG=container-mgmt
+PODS_TAG_SUFFIX="-${BUILD_TYPE}-${BUILD_TIME}" # suffix for the tag in ManageIQ-pods
+if [ "${BUILD_TYPE}" == "unstable" ]; then
+    IMAGE_REPO="manageiq-pods"       # in dockerhub
+    BASE_BRANCH="master"             # base branch for ManageIQ repos
+    PODS_BRANCH="integration-build"  # branch to use for our ManageIQ-pods fork
+    PRS_PARAM=""
+else
+    IMAGE_REPO="manageiq-pods-stable"       # in dockerhub
+    BASE_BRANCH="gaprindashvili"            # base branch for ManageIQ repos
+    PODS_BRANCH="integration-build-stable"  # branch to use for our ManageIQ-pods fork
+    PRS_PARAM="--stable"                    # parameter to pass to the PR management script
+fi
 LOCAL_REGISTRY=${LOCAL_REGISTRY:-}
 PRS_JSON=$(jq -Mc . "${PENDING_PRS}")
-BUILD_TIME=$(date +%Y%m%d-%H%M)
 SCRIPT_PATH=$(pwd)
 COMMITSTR=""
-TAG="patched-${BUILD_TIME}"
+TAG="patched-${BUILD_TYPE}-${BUILD_TIME}"
 export TAG  # needs to be exported for use with envsubst later
 
 # Even when push is done with deploy keys, we need username and password
@@ -31,9 +46,9 @@ fi
 set -u # disallow undefined variables again
 
 # Remove merged PRs from the list to avoid conflicts
-LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python2 manageiq_prs.py remove_merged
+LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python2 manageiq_prs.py remove_merged $PRS_PARAM
 # Get list of PRs used for this build
-LINKS="$(LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python2 manageiq_prs.py printlinks)"
+LINKS="$(LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python2 manageiq_prs.py printlinks $PRS_PARAM)"
 
 if [ ! -d "${BASEDIR}" ]; then
     mkdir "${BASEDIR}"
@@ -48,28 +63,29 @@ for repo in ${repos}; do
     if [ -d "${repo}" ]; then
         echo "${repo} is already cloned, updating"
         pushd "${repo}"
-        # Clean up the repo and make sure it's in sync with upstream master
-        git checkout master
+        # Clean up the repo and make sure it's in sync with upstream base branch
+        git checkout ${BASE_BRANCH}
         git clean -xdf
         git reset HEAD --hard
         git branch -D ${BRANCH}
-        git pull origin master
+        git pull origin ${BASE_BRANCH}
     else
         git clone "https://github.com/ManageIQ/${repo}"
         pushd "${repo}"
         git remote add "${GITHUB_ORG}" "git@github.com:${GITHUB_ORG}/${repo}"
+        git checkout ${BASE_BRANCH}
     fi
 
     # Save the HEAD ref, so we know which upstream commit was the latest
     # when we rolled the build.
     MASTER_HEAD=$(git rev-parse --short HEAD)
-    echo "Master is: ${MASTER_HEAD}"
-    COMMITSTR="${COMMITSTR}"$'\n'"${repo} master HEAD was https://github.com/ManageIQ/${repo}/commit/${MASTER_HEAD}"
+    echo "${BASE_BRANCH} is: ${MASTER_HEAD}"
+    COMMITSTR="${COMMITSTR}"$'\n'"${repo} ${BASE_BRANCH} HEAD was https://github.com/ManageIQ/${repo}/commit/${MASTER_HEAD}"
 
     # tag this HEAD to mark it was the HEAD for the current BUILD_TIME
     git tag "head-${BUILD_TIME}"
-    # make sure our master is up to date with upstream, so the tag would be meaningful
-    git push --tags ${GITHUB_ORG} master
+    # make sure our base branch is up to date with upstream, so the tag would be meaningful
+    git push --tags ${GITHUB_ORG} ${BASE_BRANCH}
 
     #weird bash hack
     string_escaped_repo=\"${repo}\"
@@ -124,31 +140,32 @@ popd
 # in a way that keeps their git history
 
 git fetch "${GITHUB_ORG}"
-git checkout integration-build
+git checkout -B ${PODS_BRANCH}
 
 pushd miq-app
 # Note: we modify the URL for the manageiq tarball instead of modifying REF
 # because we don't patch manageiq-appliance
-sed "s/GHORG=ManageIQ/GHORG=${GITHUB_ORG}/g" < Dockerfile.orig | sed 's/manageiq\/tarball\/${REF}/manageiq\/tarball\/image-unstable/g' > Dockerfile
+sed "s/GHORG=ManageIQ/GHORG=${GITHUB_ORG}/g" < Dockerfile.orig | sed 's/manageiq\/tarball\/${REF}/manageiq\/tarball\/'"${TAG}"'/g' > Dockerfile
 echo "Modified miq-app dockerfile"
-git diff Dockerfile
+git diff Dockerfile | cat
 git add Dockerfile
 popd
 
 pushd miq-app-frontend
 # Not setting GHORG here because we don't patch manageiq-ui-service
-sed "s/FROM manageiq\/manageiq-pods:backend-latest/FROM containermgmt\/manageiq-pods:backend-${BUILD_TIME}/g" < Dockerfile.orig > Dockerfile
-echo "$LINKS" > docker-assets/patches.txt
+sed "s/FROM manageiq\/manageiq-pods:backend-latest/FROM containermgmt\/${IMAGE_REPO}:backend${PODS_TAG_SUFFIX}/g" < Dockerfile.orig > Dockerfile
+echo "${BUILD_TYPE} build, ${BUILD_TIME} (Jenkins ID: ${BUILD_ID})" > docker-assets/patches.txt
+echo "$LINKS" >> docker-assets/patches.txt
 echo -e "\nBase refs:\n${COMMITSTR}" >> docker-assets/patches.txt
 echo "COPY docker-assets/patches.txt /patches.txt" >> Dockerfile
-git diff docker-assets/patches.txt
-git diff Dockerfile
+git diff docker-assets/patches.txt | cat
+git diff Dockerfile | cat
 git add Dockerfile
 git add docker-assets/patches.txt
 popd
 
 git commit -F- <<EOF
-Automated image build ${BUILD_TIME}
+Automated ${BUILD_TYPE} image build ${BUILD_TIME}
 Jenkins ID: ${BUILD_ID}
 
 Using PRs:
@@ -159,22 +176,24 @@ EOF
 # We need two tags (instead of just one) to force the DockerHub automated build
 # to build two images from the same repository. It's a bit of a hack, but
 # that's what the ManageIQ people do for their builds as well.
-git tag "backend-${BUILD_TIME}"
-git push --force --tags ${GITHUB_ORG} integration-build
+echo "pushing backend tag"
+git tag "backend${PODS_TAG_SUFFIX}"
+git push --force --tags ${GITHUB_ORG} ${PODS_BRANCH}
 sleep 15  # HACK: push the backend tag first in hopes DockerHub will build it before building the frontend tag
-git tag "frontend-${BUILD_TIME}"
-git push --force --tags ${GITHUB_ORG} integration-build
+git tag "frontend${PODS_TAG_SUFFIX}"
+echo "pushing frontend tag"
+git push --force --tags ${GITHUB_ORG} ${PODS_BRANCH}
 echo "Pushed manageiq-pods, 🐋dockerhub/dockercloud should do the rest."
 cd "${SCRIPT_PATH}"
 if [ ! -z "${DOCKERCLOUD_PASS}" ]; then
-    LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python2 poll_dockercloud.py "${BUILD_TIME}"
+    LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 python2 poll_dockercloud.py "${IMAGE_REPO}" "${BUILD_TIME}"
 fi
 
 if [ ! -z "${LOCAL_REGISTRY}" ]; then
     echo "Pulling image..."
-    docker pull containermgmt/manageiq-pods
+    docker pull containermgmt/${IMAGE_REPO}
     echo "Pushing to local registry..."
-    docker tag containermgmt/manageiq-pods "${LOCAL_REGISTRY}/containermgmt/manageiq-pods"
-    docker push "${LOCAL_REGISTRY}/containermgmt/manageiq-pods"
+    docker tag containermgmt/${IMAGE_REPO} "${LOCAL_REGISTRY}/containermgmt/${IMAGE_REPO}"
+    docker push "${LOCAL_REGISTRY}/containermgmt/${IMAGE_REPO}"
 fi
 echo "Done!"

--- a/manageiq-use-forked.patch.in
+++ b/manageiq-use-forked.patch.in
@@ -1,15 +1,15 @@
-From a5ee18c5d26e848ceca454d15b742260ef27dab0 Mon Sep 17 00:00:00 2001
+From aaf47c58b1f6641156e9d21273036ef93bd0465e Mon Sep 17 00:00:00 2001
 From: Scott Weiss <sdw35@cornell.edu>
 Date: Wed, 20 Sep 2017 13:59:56 -0400
 Subject: [PATCH] use forked versions for manageiq-providers-{os,k8s},
  ui-classic
 
 ---
- Gemfile | 12 +++++++++---
- 1 file changed, 9 insertions(+), 3 deletions(-)
+ Gemfile | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/Gemfile b/Gemfile
-index 9028e563e6..3b1022b145 100644
+index 9346ecea9b..8181f281f4 100644
 --- a/Gemfile
 +++ b/Gemfile
 @@ -17,6 +17,12 @@ def manageiq_plugin(plugin_name)
@@ -25,7 +25,7 @@ index 9028e563e6..3b1022b145 100644
  manageiq_plugin "manageiq-providers-ansible_tower" # can't move this down yet, because we can't autoload ManageIQ::Providers::AnsibleTower::Shared
  manageiq_plugin "manageiq-schema"
 
-@@ -105,7 +111,7 @@ group :hawkular, :manageiq_default do
+@@ -106,7 +112,7 @@ group :hawkular, :manageiq_default do
  end
 
  group :kubernetes, :openshift, :manageiq_default do
@@ -33,8 +33,8 @@ index 9028e563e6..3b1022b145 100644
 +  cm_integration_plugin "manageiq-providers-kubernetes"
  end
 
- group :lenovo, :manageiq_default do
-@@ -121,7 +127,7 @@ group :qpid_proton, :optional => true do
+ group :kubevirt, :manageiq_default do
+@@ -126,7 +132,7 @@ group :qpid_proton, :optional => true do
  end
 
  group :openshift, :manageiq_default do
@@ -43,7 +43,16 @@ index 9028e563e6..3b1022b145 100644
    gem "htauth",                         "2.0.0",         :require => false # used by container deployment
  end
 
-@@ -184,7 +190,7 @@ group :consumption, :manageiq_default do
+@@ -168,7 +174,7 @@ group :replication, :manageiq_default do
+ end
+
+ group :rest_api, :manageiq_default do
+-  manageiq_plugin "manageiq-api"
++  cm_integration_plugin "manageiq-api"
+ end
+
+ group :scheduler, :manageiq_default do
+@@ -189,7 +195,7 @@ group :consumption, :manageiq_default do
  end
 
  group :ui_dependencies do # Added to Bundler.require in config/application.rb

--- a/manageiq_prs.py
+++ b/manageiq_prs.py
@@ -21,11 +21,11 @@
 manageiq_prs: Manage ManageIQ pending PRs for the docker build
 
 Usage:
-  ./manageiq_prs.py add <repo>/<pr>
-  ./manageiq_prs.py remove <repo>/<pr>
-  ./manageiq_prs.py check [<repo>/<pr>]
-  ./manageiq_prs.py remove_merged
-  ./manageiq_prs.py printlinks
+  ./manageiq_prs.py add <repo>/<pr> [--stable]
+  ./manageiq_prs.py remove <repo>/<pr> [--stable]
+  ./manageiq_prs.py check [<repo>/<pr>] [--stable]
+  ./manageiq_prs.py remove_merged [--stable]
+  ./manageiq_prs.py printlinks [--stable]
   ./manageiq_prs.py -h | --help
 
 Options:
@@ -153,7 +153,12 @@ def remove_merged(current):
 
 
 def main():
+    global PRS_JSON
     arguments = docopt(__doc__)
+    if arguments['--stable']:
+        PRS_JSON = "pending-prs-stable.json"
+    else:
+        PRS_JSON = "pending-prs-unstable.json"
     with open(PRS_JSON, 'r') as f:
         current = json.load(f, object_pairs_hook=collections.OrderedDict)
 
@@ -217,6 +222,7 @@ def main():
         msg = "✔️  {repo} PR #{pr} was {verb} 👍".format(repo=repo, pr=pr,
                                                         verb=verb)
         print(color("OK: ", "green") + msg)
+
 
 if __name__ == "__main__":
     main()

--- a/pending-prs-stable.json
+++ b/pending-prs-stable.json
@@ -1,8 +1,7 @@
 {
-  "manageiq": [16310, 16339],
-  "manageiq-api": [76],
-  "manageiq-appliance": [],
-  "manageiq-providers-kubernetes": [140, 149],
-  "manageiq-providers-openshift": [],
-  "manageiq-ui-classic": [2289, 2497, 2491, 2579]
+    "manageiq": [], 
+    "manageiq-api": [], 
+    "manageiq-providers-kubernetes": [], 
+    "manageiq-providers-openshift": [], 
+    "manageiq-ui-classic": []
 }


### PR DESCRIPTION
This PR adds support for building ManageIQ integration images from the stable branch.

To make a stable build, jenkins would need to pass the `stable` parameter to `build.sh`.

Note regarding branching strategy of cm-integration:

I see no benefit in using more than one branch on this repo. Because the build script should do exactly the same actions for each ManageIQ version, it'd be identical between branches, and the only file that would be different between them is the pending PRs list.

So using any kind of branching scheme would just add overhead with no real benefit. As such, the master branch should be used for building both stable and unstable integration images.

## Summary of changes: 

- Added the `--stable` parameter to the PR management script, which should be used when you want to edit the PRs pending for stable
- Moved a lot of hardcoded strings to variables, so two "build types" can be used
- Changed the manageiq-pods tagging scheme to add "unstable" or "stable" to the git tag
- Configured the Docker Cloud automated build settings to watch the tag with "-unstable-" for unstable builds, and created a new repo for stable builds.